### PR TITLE
Use zoom as gconf picture-options for background and screensaver

### DIFF
--- a/backgrounds/10_org.gnome.desktop.background.default.gschema.override
+++ b/backgrounds/10_org.gnome.desktop.background.default.gschema.override
@@ -1,5 +1,5 @@
 [org.gnome.desktop.background]
 picture-uri='file:///usr/share/backgrounds/centos.xml'
-picture-options='scaled'
+picture-options='zoom'
 primary-color='#000000000000'
 secondary-color='#000000000000'

--- a/backgrounds/10_org.gnome.desktop.screensaver.default.gschema.override
+++ b/backgrounds/10_org.gnome.desktop.screensaver.default.gschema.override
@@ -1,5 +1,5 @@
 [org.gnome.desktop.screensaver]
 picture-uri='file:///usr/share/backgrounds/centos.xml'
-picture-options='scaled'
+picture-options='zoom'
 primary-color='#000000000000'
 secondary-color='#000000000000'


### PR DESCRIPTION
In desktop-backgrounds-default.xml default option is zoom while in gconf overrides it's scaled.
This leads to black empty spaces above and under wallpaper for most resolutions.

This PR unifies options in xml and gconf overrides. 