### PR TITLE
fix: 🐛 add day and night background selectors

### DIFF
--- a/backgrounds/desktop-backgrounds-default.xml
+++ b/backgrounds/desktop-backgrounds-default.xml
@@ -15,4 +15,20 @@
         <filename>/usr/share/backgrounds/centos.xml</filename>
         <options>zoom</options>
     </wallpaper>
+    <wallpaper deleted="false">
+        <name>CentOS Background Day</name>
+        <filename>/usr/share/backgrounds/centos-day.png</filename>
+        <options>zoom</options>
+        <shade_type>solid</shade_type>
+        <pcolor>#a14f8c</pcolor>
+        <scolor>#200735</scolor>
+    </wallpaper>
+    <wallpaper deleted="false">
+        <name>CentOS Background Night</name>
+        <filename>/usr/share/backgrounds/centos-night.png</filename>
+        <options>zoom</options>
+        <shade_type>solid</shade_type>
+        <pcolor>#a14f8c</pcolor>
+        <scolor>#200735</scolor>
+    </wallpaper>
 </wallpapers>


### PR DESCRIPTION
Previously, it was not possible to make static selections of light or dark backgrounds in different styles selections (e.g., it was not possible to load light background in dark mode and vice-versa). This PR adds static selectors for light and dark backgrounds so you can select different backgrounds no matter the what style selection is active.

Here is a graphical representation, you could use to validate the background selectors:

![gnome-background-selectors](https://github.com/user-attachments/assets/de102983-4460-4508-a297-3f8a7b462231)