### PR TITLE
Override `org.gnome.desktop.background.picture-uri-dark`

### DIFF
--- a/backgrounds/10_org.gnome.desktop.background.default.gschema.override
+++ b/backgrounds/10_org.gnome.desktop.background.default.gschema.override
@@ -1,5 +1,6 @@
 [org.gnome.desktop.background]
 picture-uri='file:///usr/share/backgrounds/centos.xml'
+picture-uri-dark='file:///usr/share/backgrounds/centos-night.png'
 picture-options='zoom'
 primary-color='#000000000000'
 secondary-color='#000000000000'


### PR DESCRIPTION
This makes the `centos-night.png` shows up by default when the dark style is selected.

Fixes: #8 