### PR TITLE
Set GNOME defaults to day and night images, not the animated XML

### DIFF
--- a/backgrounds/10_org.gnome.desktop.background.default.gschema.override
+++ b/backgrounds/10_org.gnome.desktop.background.default.gschema.override
@@ -1,5 +1,6 @@
 [org.gnome.desktop.background]
-picture-uri='file:///usr/share/backgrounds/centos.xml'
+picture-uri='file:///usr/share/backgrounds/centos-day.png'
+picture-uri-dark='file:///usr/share/backgrounds/centos-night.png'
 picture-options='zoom'
 primary-color='#000000000000'
 secondary-color='#000000000000'


### PR DESCRIPTION
GNOME handling of light and dark backgrounds has changed.  With a default install of C10S, or with the GNOME AltImage, if you enable Dark Style, then the background goes black.  The reason being is that picture-uri-dark is an expected value, and without an override, the upstream default is attempted but does not exist since gnome-backgrounds is not shipped.

Based on the corresponding change for F36 by @AdamWill:

https://src.fedoraproject.org/rpms/desktop-backgrounds/c/14f7bbc4ae095bb548255a1c3dfa90753a0913e0

/cc @tdawson